### PR TITLE
fix: lost first character when inject code

### DIFF
--- a/src/core/transformer.ts
+++ b/src/core/transformer.ts
@@ -107,8 +107,8 @@ async function transformComponent(
 
 	if (ast.instance) {
 		const start = ast.instance.start
-
-		const index = start + (code.slice(start).indexOf(">") + 2)
+        
+		const index = code.indexOf(">", start) + 1
 
 		const oc = s.toString()
 
@@ -120,7 +120,7 @@ async function transformComponent(
 			return item
 		})
 
-		s.overwrite(index, index + 1, `\n ${imports.join("\n")} \n`)
+		s.appendRight(index, `\n${imports.join("\n")}\n`)
 	} else {
 		const script = `<script>${imports.join("\n")}</script>`
 


### PR DESCRIPTION
when using like

```html
<script lang='ts'>import Header from './Header.svelte';
</script>
```
current transform is also remove `i` from `import ...` because assume whitespace after `<script>` tag and `s.override(index, index + 1)` cause code to be remove

try [here stackblitz](https://stackblitz.com/edit/sveltejs-kit-template-default-dqpebb?file=src%2Froutes%2F%2Blayout.svelte,src%2Fapp.d.ts)